### PR TITLE
Add level parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,15 @@ Log line with simple message:
 }
 ```
 
+The default log level is INFO, you can overwrite this by providing the
+`$LOG_LEVEL` environmental variable or setting the log level in
+`Logr::Logger.new`. If you'd like to use `$LOG_LEVEL` for something
+else you can use another env variable name by passing the name to
+`Logr::Logger.new` as below:
+```ruby
+Logr::Logger.new('your-logger-name', level: Logr.parse_level(var: 'YOUR_ENV_VARIABLE'))
+```
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/lib/logr.rb
+++ b/lib/logr.rb
@@ -2,4 +2,18 @@ require "logr/version"
 require "logr/logger"
 
 module Logr
+  # Parse log level from an environment variable
+  #
+  # @param default [Symbol] the default log level
+  # @param var [String] the environment variable to use
+  # @return the parsed logger level as a number
+  def self.parse_level(default: :info, var: "LOG_LEVEL")
+    valid_levels = %w[DEBUG INFO WARN ERROR FATAL UNKNOWN]
+
+    default = default.upcase
+    level = ENV.fetch(var, default).upcase.to_s
+    level = valid_levels.find(-> { default }) { |lvl| lvl == level }
+
+    ::Logger.const_get(level)
+  end
 end

--- a/lib/logr.rb
+++ b/lib/logr.rb
@@ -1,45 +1,5 @@
-require "logger"
-
 require "logr/version"
-require "logr/entry"
-require "logr/json_formatter"
+require "logr/logger"
 
 module Logr
-  class Logger
-    def initialize(name, level: ::Logger::INFO, log_device: STDOUT)
-      @logger = ::Logger.new(log_device).tap do |logger|
-        logger.formatter = JSONFormatter.new
-        logger.progname = name
-        logger.level = level
-      end
-    end
-
-    def event(name, tags={})
-      Entry.new(@logger).event(name, tags)
-    end
-
-    def metric(name, value, type: "counter")
-      Entry.new(@logger).metric(name, value, type: type)
-    end
-
-    def debug(message)
-      Entry.new(@logger).debug(message)
-    end
-
-    def info(message)
-      Entry.new(@logger).info(message)
-    end
-
-    def warn(message)
-      Entry.new(@logger).warn(message)
-    end
-
-    def error(message)
-      Entry.new(@logger).error(message)
-    end
-
-    def fatal(message)
-      Entry.new(@logger).fatal(message)
-    end
-  end
 end

--- a/lib/logr/logger.rb
+++ b/lib/logr/logger.rb
@@ -5,7 +5,7 @@ require "logr/json_formatter"
 
 module Logr
   class Logger
-    def initialize(name, level: ::Logger::INFO, log_device: STDOUT)
+    def initialize(name, level: Logr.parse_level, log_device: STDOUT)
       @logger = ::Logger.new(log_device).tap do |logger|
         logger.formatter = JSONFormatter.new
         logger.progname = name

--- a/lib/logr/logger.rb
+++ b/lib/logr/logger.rb
@@ -1,0 +1,44 @@
+require "logger"
+
+require "logr/entry"
+require "logr/json_formatter"
+
+module Logr
+  class Logger
+    def initialize(name, level: ::Logger::INFO, log_device: STDOUT)
+      @logger = ::Logger.new(log_device).tap do |logger|
+        logger.formatter = JSONFormatter.new
+        logger.progname = name
+        logger.level = level
+      end
+    end
+
+    def event(name, tags={})
+      Entry.new(@logger).event(name, tags)
+    end
+
+    def metric(name, value, type: "counter")
+      Entry.new(@logger).metric(name, value, type: type)
+    end
+
+    def debug(message)
+      Entry.new(@logger).debug(message)
+    end
+
+    def info(message)
+      Entry.new(@logger).info(message)
+    end
+
+    def warn(message)
+      Entry.new(@logger).warn(message)
+    end
+
+    def error(message)
+      Entry.new(@logger).error(message)
+    end
+
+    def fatal(message)
+      Entry.new(@logger).fatal(message)
+    end
+  end
+end

--- a/spec/logr/logger_spec.rb
+++ b/spec/logr/logger_spec.rb
@@ -3,7 +3,7 @@ require 'logger'
 require 'json'
 require 'timecop'
 
-describe Logr do
+describe Logr::Logger do
   context 'DEBUG log level' do
     let(:test_output) { StringIO.new }
     let(:logger) { Logr::Logger.new('test_logger', level: Logger::DEBUG, log_device: test_output) }

--- a/spec/logr_spec.rb
+++ b/spec/logr_spec.rb
@@ -1,0 +1,50 @@
+require "spec_helper"
+
+describe Logr do
+  describe "parse_level" do
+    it "parses the LOG_LEVEL environment variable" do
+      with_env("LOG_LEVEL", "error") do
+        expect(Logr.parse_level).to eq(Logger::ERROR)
+      end
+    end
+
+    it "allows to specify the name of the environment variable" do
+      with_env("CUSTOM_LOG_LEVEL", "warn") do
+        expect(Logr.parse_level(var: "CUSTOM_LOG_LEVEL")).to eq(Logger::WARN)
+      end
+    end
+
+    it "allows the default level to be set" do
+      expect(Logr.parse_level(default: :warn)).to eq(Logger::WARN)
+    end
+
+    it "defaults to info without any configuration" do
+      expect(Logr.parse_level).to eq(Logger::INFO)
+    end
+
+    it "is case insensitive" do
+      with_env("LOG_LEVEL", "warn") do
+        expect(Logr.parse_level).to eq(Logger::WARN)
+      end
+
+      with_env("LOG_LEVEL", "WARN") do
+        expect(Logr.parse_level).to eq(Logger::WARN)
+      end
+    end
+
+    it "rejects not allowed level strings and returns default" do
+      with_env("LOG_LEVEL", "not-a-level") do
+        expect(Logr.parse_level(default: :error)).to eq(Logger::ERROR)
+      end
+    end
+  end
+
+  def with_env(key, value)
+    key, value = key.to_s, value.to_s
+    past = ENV[key]
+    ENV[key] = value
+    yield
+    ENV[key] = past
+  end
+end
+


### PR DESCRIPTION
- Small refactor: moving `Logr::Logger` to its own file
- Add a function to parse log levels from the environment
